### PR TITLE
Slack alerts option

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -61,6 +61,17 @@ walle_envs_user_deletion:
 walle_verbose: false
 walle_kill: false
 
+walle_slack_alerts: false
+walle_slack_api_token: null  # Make a "Slack app" to get a token
+walle_slack_channel_id: null  # Copy from your Slack channel settings
+walle_envs_slack:
+  - key: SLACK_API_TOKEN
+    value: "{{ walle_slack_api_token }}"
+  - key: SLACK_CHANNEL_ID
+    value: "{{ walle_slack_channel_id }}"
+  - key: WALLE_HOSTNAME
+    value: "{{ inventory_hostname }}"
+
 # Cron
 walle_cron_day: "*"
 walle_cron_hour: "*/1"

--- a/files/walle.py
+++ b/files/walle.py
@@ -824,6 +824,7 @@ def post_slack_msg(message):
                        " [walle_slack_api_token, walle_slack_channel_id].")
         return
 
+    logger.info(f"Posting incident report to Slack channel {channel_id}...")
     requests.post(
         SLACK_URL,
         json={

--- a/files/walle.py
+++ b/files/walle.py
@@ -210,7 +210,9 @@ Use like 'grep' after the gxadmin query queue-details command.",
         help="Show table header.",
     )
     my_parser.add_argument(
-        "--slack-alerts", action="store_true", help=(
+        "--slack-alerts",
+        action="store_true",
+        help=(
             "Report matches to a Slack channel defined with env variables"
             " [SLACK_API_TOKEN, SLACK_CHANNEL_ID], where the Slack token"
             " authenticates a Slack App with permission to post in your"
@@ -819,9 +821,11 @@ def post_slack_msg(message):
     channel_id = os.getenv("SLACK_CHANNEL_ID")
 
     if not all([key, channel_id]):
-        logger.warning("Slack notifications cannot be sent. Make sure your"
-                       " playbook defines required vars:"
-                       " [walle_slack_api_token, walle_slack_channel_id].")
+        logger.warning(
+            "Slack notifications cannot be sent. Make sure your"
+            " playbook defines required vars:"
+            " [walle_slack_api_token, walle_slack_channel_id]."
+        )
         return
 
     logger.info(f"Posting incident report to Slack channel {channel_id}...")
@@ -832,7 +836,7 @@ def post_slack_msg(message):
             "channel": channel_id,
         },
         headers={
-            "Authorization": f'Bearer {key}',
+            "Authorization": f"Bearer {key}",
         },
     )
 

--- a/files/walle.py
+++ b/files/walle.py
@@ -818,7 +818,7 @@ def post_slack_msg(message):
     key = os.getenv("SLACK_API_TOKEN")
     channel_id = os.getenv("SLACK_CHANNEL_ID")
 
-    if not all(key, channel_id):
+    if not all([key, channel_id]):
         logger.warning("Slack notifications cannot be sent. Make sure your"
                        " playbook defines required vars:"
                        " [walle_slack_api_token, walle_slack_channel_id].")

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,6 +54,14 @@
     owner: "{{ walle_user_name }}"
     group: "{{ walle_user_group }}"
 
+- name: Add env variables for slack notifications (WallE)
+  ansible.builtin.lineinfile:
+    path: "{{ walle_bashrc }}"
+    regexp: "^export {{ item.key }}="
+    line: 'export {{ item.key }}="{{ item.value }}"'
+  with_items: "{{ walle_envs_slack }}"
+  when: walle_slack_alerts
+
 - name: Create logfile (WallE)
   ansible.builtin.file:
     state: touch
@@ -99,6 +107,7 @@
       {% if walle_filesize_max %} --max-size {{ walle_filesize_max }} {% endif %}
       {% if walle_since_hours %} --since {{ walle_since_hours }} {% endif %}
       {% if walle_verbose %} --verbose {% endif %}
+      {% if walle_slack_alerts %} --slack-alerts {% endif %}
       {% if walle_delete_users %} --delete-user {{ walle_delete_threshold }}
       {% endif %}
       {% if walle_kill %} --kill {% endif %}


### PR DESCRIPTION
Add an option to get Slack alerts when a match is found. This will probably need to be rebased again when https://github.com/usegalaxy-eu/WallE/pull/7 is merged.

Introduces three new Ansible vars:

```yml
walle_slack_alerts: true
walle_slack_api_token: "{{ vault_walle_slack_api_token }}"
walle_slack_channel_id: "{{ vault_walle_slack_channel_id }}"
```

Where `walle_slack_api_token` is used authenticate a Slack App that has permission to post to your workspace and `walle_slack_channel_id` is the channel ID for the Slack channel that WALL-E will post in.

The Slack reports look like this:

![image](https://github.com/user-attachments/assets/27983414-c1ff-47d1-ac6c-f5e0acd45d6b)

Where "Hostname" defaults to the playbook's `{{ inventory_hostname }}` but could be modified by over-riding the env var `WALLE_HOSTNAME` (this depends on resolving issue https://github.com/usegalaxy-eu/WallE/issues/9).