### PR TITLE
Slack alert throttle

### DIFF
--- a/files/.gitignore
+++ b/files/.gitignore
@@ -1,0 +1,8 @@
+# Virtual Environments
+venv/
+.venv/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class

--- a/files/requirements.txt
+++ b/files/requirements.txt
@@ -1,3 +1,3 @@
-psycopg2-binary
-requests
-pyyaml
+psycopg2-binary>=2.9,<3.0
+PyYAML>=6.0,<7.0
+requests>=2.32,<3.0

--- a/files/requirements.txt
+++ b/files/requirements.txt
@@ -1,0 +1,3 @@
+psycopg2-binary
+requests
+pyyaml

--- a/files/test.py
+++ b/files/test.py
@@ -9,7 +9,6 @@ SLACK_NOTIFY_PERIOD_DAYS = 7
 
 
 class TestNotificationHistory(unittest.TestCase):
-
     def setUp(self):
         self.temp_file = tempfile.NamedTemporaryFile(delete=False)
         self.record = NotificationHistory(self.temp_file.name)

--- a/files/test.py
+++ b/files/test.py
@@ -19,24 +19,22 @@ class TestNotificationHistory(unittest.TestCase):
 
     def test_contains_new_entry(self):
         jwd = "unique_id_1"
-        self.assertFalse(self.record.contains(jwd),
-                         "New entry should initially return False")
-        self.assertTrue(self.record.contains(jwd),
-                        "Duplicate entry should return True")
+        self.assertFalse(
+            self.record.contains(jwd), "New entry should initially return False"
+        )
+        self.assertTrue(self.record.contains(jwd), "Duplicate entry should return True")
 
     def test_contains_existing_entry(self):
         jwd = "existing_id"
         with open(self.temp_file.name, "a") as f:
             f.write(f"{datetime.now()}\t{jwd}\n")
-        self.assertTrue(self.record.contains(jwd),
-                        "Existing entry should return True")
+        self.assertTrue(self.record.contains(jwd), "Existing entry should return True")
 
     @patch("walle.SLACK_NOTIFY_PERIOD_DAYS", new=SLACK_NOTIFY_PERIOD_DAYS)
     def test_truncate_old_records(self):
         old_jwd = "old_entry"
         recent_jwd = "recent_entry"
-        old_date = datetime.now() - timedelta(
-            days=SLACK_NOTIFY_PERIOD_DAYS + 1)
+        old_date = datetime.now() - timedelta(days=SLACK_NOTIFY_PERIOD_DAYS + 1)
         recent_date = datetime.now()
 
         with open(self.temp_file.name, "a") as f:
@@ -44,10 +42,8 @@ class TestNotificationHistory(unittest.TestCase):
             f.write(f"{recent_date.isoformat()}\t{recent_jwd}\n")
 
         self.record._truncate_records()
-        self.assertFalse(self.record.contains(old_jwd),
-                         "Old entry should be purged")
-        self.assertTrue(self.record.contains(recent_jwd),
-                        "Recent entry should remain")
+        self.assertFalse(self.record.contains(old_jwd), "Old entry should be purged")
+        self.assertTrue(self.record.contains(recent_jwd), "Recent entry should remain")
 
     def test_purge_invalid_records(self):
         with open(self.temp_file.name, "w") as f:
@@ -57,8 +53,8 @@ class TestNotificationHistory(unittest.TestCase):
             self.record._read_records()
             mock_warning.assert_called()
 
-        self.assertFalse(self.record._get_jwds(),
-                         "Invalid records should be purged")
+        self.assertFalse(self.record._get_jwds(), "Invalid records should be purged")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/files/test.py
+++ b/files/test.py
@@ -3,67 +3,62 @@ from unittest.mock import patch
 from datetime import datetime, timedelta
 import pathlib
 import tempfile
-from walle import NotificationRecord  # Replace 'your_module' with the actual module name
+from walle import NotificationHistory
 
-SLACK_NOTIFY_PERIOD_DAYS = 7  # Define a mock value for testing
+SLACK_NOTIFY_PERIOD_DAYS = 7
 
 
-class TestNotificationRecord(unittest.TestCase):
+class TestNotificationHistory(unittest.TestCase):
 
     def setUp(self):
-        # Create a temporary file for testing
         self.temp_file = tempfile.NamedTemporaryFile(delete=False)
-        self.record = NotificationRecord(self.temp_file.name)
+        self.record = NotificationHistory(self.temp_file.name)
 
     def tearDown(self):
-        # Clean up the temporary file
         pathlib.Path(self.temp_file.name).unlink(missing_ok=True)
 
-    def test_posted_for_new_entry(self):
-        # Test if a new notification gets posted
+    def test_contains_new_entry(self):
         jwd = "unique_id_1"
-        self.assertFalse(self.record.posted_for(jwd), "New entry should return False initially")
-        self.assertTrue(self.record.posted_for(jwd), "After posting, entry should return True")
+        self.assertFalse(self.record.contains(jwd),
+                         "New entry should initially return False")
+        self.assertTrue(self.record.contains(jwd),
+                        "Duplicate entry should return True")
 
-    def test_posted_for_existing_entry(self):
-        # Write a notification to the record file
+    def test_contains_existing_entry(self):
         jwd = "existing_id"
         with open(self.temp_file.name, "a") as f:
             f.write(f"{datetime.now()}\t{jwd}\n")
-        self.assertTrue(self.record.posted_for(jwd), "Existing entry should return True")
+        self.assertTrue(self.record.contains(jwd),
+                        "Existing entry should return True")
 
     @patch("walle.SLACK_NOTIFY_PERIOD_DAYS", new=SLACK_NOTIFY_PERIOD_DAYS)
     def test_truncate_old_records(self):
-        # Write an old and a recent notification
         old_jwd = "old_entry"
         recent_jwd = "recent_entry"
-        old_date = datetime.now() - timedelta(days=SLACK_NOTIFY_PERIOD_DAYS + 1)
+        old_date = datetime.now() - timedelta(
+            days=SLACK_NOTIFY_PERIOD_DAYS + 1)
         recent_date = datetime.now()
 
         with open(self.temp_file.name, "a") as f:
             f.write(f"{old_date.isoformat()}\t{old_jwd}\n")
             f.write(f"{recent_date.isoformat()}\t{recent_jwd}\n")
 
-        # Check truncation
         self.record._truncate_records()
-        self.assertFalse(self.record.posted_for(old_jwd), "Old entry should be purged")
-        self.assertTrue(self.record.posted_for(recent_jwd), "Recent entry should remain")
+        self.assertFalse(self.record.contains(old_jwd),
+                         "Old entry should be purged")
+        self.assertTrue(self.record.contains(recent_jwd),
+                        "Recent entry should remain")
 
     def test_purge_invalid_records(self):
-        # Write an invalid entry to the record file
         with open(self.temp_file.name, "w") as f:
             f.write("invalid_date\tinvalid_path\n")
 
         with patch("walle.logger.warning") as mock_warning:
             self.record._read_records()
-            mock_warning.assert_called_once_with(
-                f"Invalid records found in {self.temp_file.name}. The"
-                " file will be purged. This may result in duplicate Slack"
-                " notifications."
-            )
+            mock_warning.assert_called()
 
-        # Check that file is purged
-        self.assertFalse(self.record._get_jwds(), "Invalid records should be purged")
+        self.assertFalse(self.record._get_jwds(),
+                         "Invalid records should be purged")
 
 if __name__ == "__main__":
     unittest.main()

--- a/files/test.py
+++ b/files/test.py
@@ -25,8 +25,7 @@ class TestNotificationHistory(unittest.TestCase):
 
     def test_contains_existing_entry(self):
         jwd = "existing_id"
-        with open(self.temp_file.name, "a") as f:
-            f.write(f"{datetime.now()}\t{jwd}\n")
+        self.record._write_record(jwd)
         self.assertTrue(self.record.contains(jwd), "Existing entry should return True")
 
     @patch("walle.SLACK_NOTIFY_PERIOD_DAYS", new=SLACK_NOTIFY_PERIOD_DAYS)

--- a/files/walle.py
+++ b/files/walle.py
@@ -63,7 +63,9 @@ class NotificationRecord:
     """Record of Slack notifications to avoid spamming users."""
 
     def __init__(self, record_file: str) -> None:
-        self.record_file = record_file
+        self.record_file = pathlib.Path(record_file)
+        if not self.record_file.exists():
+            self.record_file.touch()
         self._truncate_records()
 
     def _get_jwds(self) -> List[str]:

--- a/files/walle.py
+++ b/files/walle.py
@@ -67,13 +67,14 @@ def convert_arg_to_seconds(hours: str) -> float:
 @dataclass
 class Record:
     date: str
-    jwd: Union[str, pathlib.Path]
+    jwd: str
 
     def __post_init__(self):
         if not (
             isinstance(self.date, str) and isinstance(self.jwd, (str, pathlib.Path))
         ):
             raise ValueError
+        self.jwd = str(self.jwd)
         datetime.fromisoformat(self.date)  # will raise ValueError if invalid
 
 

--- a/files/walle.py
+++ b/files/walle.py
@@ -117,7 +117,8 @@ class NotificationHistory:
                     f.write(f"{datestr}\t{jwd_path}\n")
 
     def contains(self, jwd: Union[pathlib.Path, str]) -> bool:
-        exists = str(jwd) in self._get_jwds()
+        jwd = str(jwd)
+        exists = jwd in self._get_jwds()
         if not exists:
             self._write_jwd(jwd)
         return exists

--- a/files/walle.py
+++ b/files/walle.py
@@ -86,7 +86,7 @@ class NotificationHistory:
             self.record_file.touch()
         self._truncate_records()
 
-    def _get_jwds(self) -> Record:
+    def _get_jwds(self) -> List[str]:
         return [record.jwd for record in self._read_records()]
 
     def _read_records(self) -> List[Record]:

--- a/files/walle.py
+++ b/files/walle.py
@@ -50,8 +50,8 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 GXADMIN_PATH = os.getenv("GXADMIN_PATH", "/usr/local/bin/gxadmin")
-NOTIFICATION_RECORD_FILE = os.getenv("WALLE_NOTIFICATION_RECORD_FILE",
-                                     "/tmp/walle-notifications.txt")
+NOTIFICATION_HISTORY_FILE = os.getenv("WALLE_NOTIFICATION_HISTORY_FILE",
+                                      "/tmp/walle-notifications.txt")
 
 
 def convert_arg_to_byte(mb: str) -> int:
@@ -62,7 +62,7 @@ def convert_arg_to_seconds(hours: str) -> float:
     return float(hours) * 60 * 60
 
 
-class NotificationRecord:
+class NotificationHistory:
     """Record of Slack notifications to avoid spamming users."""
 
     def __init__(self, record_file: str) -> None:
@@ -119,7 +119,7 @@ class NotificationRecord:
                 ):
                     f.write(f"{datestr}\t{jwd_path}\n")
 
-    def posted_for(self, jwd: str) -> bool:
+    def contains(self, jwd: str) -> bool:
         exists = str(jwd) in self._get_jwds()
         if not exists:
             self._write_jwd(jwd)
@@ -157,7 +157,7 @@ class Severity:
 
 
 VALID_SEVERITIES = (Severity(0, "LOW"), Severity(1, "MEDIUM"), Severity(2, "HIGH"))
-notification_record = NotificationRecord(NOTIFICATION_RECORD_FILE)
+notification_history = NotificationHistory(NOTIFICATION_HISTORY_FILE)
 
 
 def convert_str_to_severity(test_level: str) -> Severity:
@@ -477,7 +477,7 @@ class Case:
         )
 
     def post_slack_alert(self):
-        if notification_record.posted_for(self.job.jwd):
+        if notification_history.contains(self.job.jwd):
             logger.debug(
                 "Skipping Slack notification - already posted for this JWD")
             return

--- a/files/walle.py
+++ b/files/walle.py
@@ -50,8 +50,9 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 GXADMIN_PATH = os.getenv("GXADMIN_PATH", "/usr/local/bin/gxadmin")
-NOTIFICATION_HISTORY_FILE = os.getenv("WALLE_NOTIFICATION_HISTORY_FILE",
-                                      "/tmp/walle-notifications.txt")
+NOTIFICATION_HISTORY_FILE = os.getenv(
+    "WALLE_NOTIFICATION_HISTORY_FILE", "/tmp/walle-notifications.txt"
+)
 
 
 def convert_arg_to_byte(mb: str) -> int:
@@ -72,16 +73,12 @@ class NotificationHistory:
         self._truncate_records()
 
     def _get_jwds(self) -> List[str]:
-        return [
-            line[1] for line in self._read_records()
-        ]
+        return [line[1] for line in self._read_records()]
 
     def _read_records(self) -> List[str]:
         with open(self.record_file, "r") as f:
             records = [
-                line.strip().split('\t')
-                for line in f.readlines()
-                if line.strip()
+                line.strip().split("\t") for line in f.readlines() if line.strip()
             ]
         return self._validate(records)
 
@@ -95,27 +92,27 @@ class NotificationHistory:
             logger.warning(
                 f"Invalid records found in {self.record_file}. The"
                 " file will be purged. This may result in duplicate Slack"
-                " notifications.")
+                " notifications."
+            )
             self._purge_records()
             return []
         return records
 
-    def _write_jwd(self, jwd: str):
+    def _write_jwd(self, jwd: str) -> None:
         with open(self.record_file, "a") as f:
             f.write(f"{datetime.now()}\t{jwd}\n")
 
-    def _purge_records(self):
+    def _purge_records(self) -> None:
         self.record_file.unlink()
         self.record_file.touch()
 
-    def _truncate_records(self):
+    def _truncate_records(self) -> None:
         """Truncate older records."""
         records = self._read_records()
         with open(self.record_file, "w") as f:
             for datestr, jwd_path in records:
-                if (
-                    datetime.fromisoformat(datestr)
-                    > datetime.now() - timedelta(days=SLACK_NOTIFY_PERIOD_DAYS)
+                if datetime.fromisoformat(datestr) > datetime.now() - timedelta(
+                    days=SLACK_NOTIFY_PERIOD_DAYS
                 ):
                     f.write(f"{datestr}\t{jwd_path}\n")
 
@@ -478,8 +475,7 @@ class Case:
 
     def post_slack_alert(self):
         if notification_history.contains(self.job.jwd):
-            logger.debug(
-                "Skipping Slack notification - already posted for this JWD")
+            logger.debug("Skipping Slack notification - already posted for this JWD")
             return
         msg = f"""
 :rotating_light: WALLE: *Malware detected* :rotating_light:

--- a/files/walle.py
+++ b/files/walle.py
@@ -17,7 +17,7 @@ import sys
 import time
 import zlib
 from datetime import datetime, timedelta
-from typing import Dict, List
+from typing import Dict, List, Union
 
 import galaxy_jwd
 import requests
@@ -75,7 +75,7 @@ class NotificationHistory:
     def _get_jwds(self) -> List[str]:
         return [line[1] for line in self._read_records()]
 
-    def _read_records(self) -> List[str]:
+    def _read_records(self) -> List[List[str]]:
         with open(self.record_file, "r") as f:
             records = [
                 line.strip().split("\t") for line in f.readlines() if line.strip()
@@ -116,7 +116,7 @@ class NotificationHistory:
                 ):
                     f.write(f"{datestr}\t{jwd_path}\n")
 
-    def contains(self, jwd: str) -> bool:
+    def contains(self, jwd: Union[pathlib.Path, str]) -> bool:
         exists = str(jwd) in self._get_jwds()
         if not exists:
             self._write_jwd(jwd)


### PR DESCRIPTION
Resolves #14 

- Throttle slack alerts, defaults to 1 per week per JWD
- Keep a history of slack notifications in temp file (defaults to /tmp/walle-notifications.txt)

Not sure if these should live in the Ansible repo? I could just gitignore them?
- Add some tests
- Add requirements.txt
