### PR TITLE
Fix object store path suffix check

### DIFF
--- a/files/galaxy_jwd.py
+++ b/files/galaxy_jwd.py
@@ -289,7 +289,7 @@ def parse_object_store(object_store_conf: pathlib.Path) -> dict:
     """
     if object_store_conf.suffix == ".xml":
         return parse_object_store_xml(object_store_conf)
-    if object_store_conf.suffix in ("yml", "yaml"):
+    if object_store_conf.suffix in (".yml", ".yaml"):
         return parse_object_store_yaml(object_store_conf)
     raise ValueError("Invalid object store configuration file extension")
 


### PR DESCRIPTION
Walle was throwing the "Invalid object store configuration file extension" error for our object_store_conf.yml